### PR TITLE
No border for abbr-tags

### DIFF
--- a/core/layout/sass/style.scss
+++ b/core/layout/sass/style.scss
@@ -1,2 +1,7 @@
 @import '_base';
 @import '_app';
+
+abbr[title], abbr[data-original-title]
+{
+  border: none;
+}


### PR DESCRIPTION
Remove the bootstrap border for abbr-tags.
