### PR TITLE
Bug login with the wrong e-mail address

### DIFF
--- a/core/classes/authentication.php
+++ b/core/classes/authentication.php
@@ -155,7 +155,7 @@ class Authentication
 			);
 
 			$message = 'failed login attempt';
-			if($user->isBlocked) $message .= ' from blocked user';
+			if($user !== false && $user->isBlocked) $message .= ' from blocked user';
 
 			// log
 			Site::getLogger()->warning(


### PR DESCRIPTION
**Error:** 

```
Notice: Trying to get property of non-object in /home/sites/apps/ldr/tijdsregistratie/releases/20130705134306/core/classes/authentication.php on line 158
```

**Reproduce problem:** login with e-mail address that does not exist
**Solution:** check if user can be found
