### PR TITLE
no wrap on whitespace in action menu

### DIFF
--- a/core/layout/sass/_app.scss
+++ b/core/layout/sass/_app.scss
@@ -1007,6 +1007,7 @@ dl {
           text-decoration: none;
           line-height: 65px;
           overflow: hidden;
+          white-space: nowrap;
 
           &.iconList {
             @include svg-with-png-fallback(icon_list, #1f2024 no-repeat, $dimensions: false);


### PR DESCRIPTION
Met die nowrap zal de text in die action menu iet verspringen wanneer die open slide
