### PR TITLE
Fixes a bug with the datepicker and non-loaded defaults

### DIFF
--- a/core/coffee/framework.form.coffee
+++ b/core/coffee/framework.form.coffee
@@ -83,7 +83,7 @@ class Form
     )
 
   _dateFields: ->
-    $.datepicker.setDefaults Form._dateFieldOptions
+    $.datepicker.setDefaults @_dateFieldOptions
 
   _normalDateFields: ->
     $('.inputDatefieldNormal').each(() ->


### PR DESCRIPTION
The datepicker defaults weren't loaded due to a wrong references in the
coffee file. This commit fixes that issue.
