### PR TITLE
Use the User::createFromData() factory method instead of composing it

### DIFF
--- a/core/classes/authentication.php
+++ b/core/classes/authentication.php
@@ -35,10 +35,7 @@ class Authentication
 		if($data !== null)
 		{
 			// create instance
-			$user = new User();
-
-			// initialize
-			$user->initialize($data);
+			$user = User::createFromData($data);
 
 			// login again, so we stay logged in
 			self::login($user);

--- a/core/classes/default_entity.php
+++ b/core/classes/default_entity.php
@@ -44,10 +44,29 @@ abstract class DefaultEntity
     protected $editedOn;
 
     /**
+     * Create a entity from the given data
+     *
+     * @param array|null $data An array of data (key-value)
+     *
+     * @return bool|static
+     */
+    public static function createFromData($data = null)
+    {
+        if ($data === null) {
+            return false;
+        }
+
+        $item = new static();
+        $item->initialize($data);
+
+        return $item;
+    }
+
+    /**
      * initialized the log data
      * @param array $data
      */
-    public function initialize($data)
+    protected function initialize($data)
     {
         if (isset($data['id'])) {
             $this->setId($data['id']);

--- a/modules/users/model/model.php
+++ b/modules/users/model/model.php
@@ -81,24 +81,6 @@ class User extends DefaultEntity
     protected $settings = array();
 
     /**
-     * Create a user from the given data
-     *
-     * @param array|null $data
-     * @return bool|User
-     */
-    public static function createFromData($data = null)
-    {
-        if ($data === null) {
-            return false;
-        }
-
-        $item = new User();
-        $item->initialize($data);
-
-        return $item;
-    }
-
-    /**
      * Get a user
      * @param int $id The id of the user.
      * @return User
@@ -261,7 +243,7 @@ class User extends DefaultEntity
      * @param    array $data The data in an array.
      * @return User
      */
-    public function initialize($data)
+    protected function initialize($data)
     {
         parent::initialize($data);
         if (isset($data['id'])) {


### PR DESCRIPTION
- Refactored the factory method to reside in DefaultEntity class, so that
  all entities extend from DefaultEntity can benefit from it.
- Use the factory method everywhere instead of composing the user object
  ourselves with $user = new User(); $user->initialize($data);

See also the discussion in https://github.com/sumocoders/Simple-Application-Framework/pull/42
