### PR TITLE
Proposal: ArrayAccess for DefaultEntity

### DIFF
--- a/core/classes/default_entity.php
+++ b/core/classes/default_entity.php
@@ -9,7 +9,7 @@
  * @author         Jelmer Prins <jelmer@sumocoders.be>
  * @since          1.0
  */
-abstract class DefaultEntity
+abstract class DefaultEntity implements ArrayAccess
 {
     /**
      * The id of the entity.
@@ -224,5 +224,87 @@ abstract class DefaultEntity
                 'by' => Authentication::getLoggedInUser()
             )
         );
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Whether a offset exists
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     */
+    public function offsetExists($offset)
+    {
+        $fieldName = SpoonFilter::ucfirst($offset);
+        $methodName = 'get' . $fieldName;
+
+        return method_exists($this, $methodName);
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Offset to retrieve
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to retrieve.
+     *                      </p>
+     *
+     * @return mixed Can return all value types.
+     */
+    public function offsetGet($offset)
+    {
+        $fieldName = SpoonFilter::ucfirst($offset);
+        $methodName = 'get' . $fieldName;
+
+        return $this->$methodName();
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Offset to set
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to assign the value to.
+     *                      </p>
+     * @param mixed $value  <p>
+     *                      The value to set.
+     *                      </p>
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        $fieldName = SpoonFilter::ucfirst($offset);
+        $methodName = 'set' . $fieldName;
+
+        $this->$methodName($value);
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Offset to unset
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to unset.
+     *                      </p>
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        $fieldName = SpoonFilter::ucfirst($offset);
+        $methodName = 'set' . $fieldName;
+
+        $this->$methodName(null);
     }
 }


### PR DESCRIPTION
This is a proposal, with just a quick implementation.

Instead of using a toArray() function for an entity, why not implement the ArrayAccess interface?

Still todo:
- use array access where toArray is now used
- remove toArray()

Usage:

``` php
$this->item = User::get($id);

Spoon::dump(isset($this->item['id'])); // exists
Spoon::dump($this->item['id']); // get
$this->item['id'] = 1; // set
unset($this->item['id']); // unset
```
