### PR TITLE
Add a userIs() method to the BaseAction for easy user type discovery

### DIFF
--- a/core/classes/action.php
+++ b/core/classes/action.php
@@ -257,13 +257,13 @@ class SiteBaseAction
     /**
      * Check if a user's role is in a list of given roles
      *
-     * @param array $possibleRoles The list of possible roles
+     * @param string|array $possibleRoles The list of possible roles
      *
      * @return bool To be or not to be, that's the question
      */
-    protected function userIs(array $possibleRoles)
+    protected function userIs($possibleRoles)
     {
-        return in_array($this->currentUser->getType(), $possibleRoles);
+        return in_array($this->currentUser->getType(), (array) $possibleRoles);
     }
 
     /**


### PR DESCRIPTION
With this method in place you'll never have to write the in_array call
in your actions anymore to check if a user has a certain role. Just do
this instead: `$this->userIs(array('admin'))`, and you're ready!
