### PR TITLE
Fix the userIs method when not authenticated.

### DIFF
--- a/core/classes/action.php
+++ b/core/classes/action.php
@@ -263,6 +263,10 @@ class SiteBaseAction
      */
     protected function userIs($possibleRoles)
     {
+        if ($this->currentUser === null) {
+            return false;
+        }
+
         return in_array($this->currentUser->getType(), (array) $possibleRoles);
     }
 


### PR DESCRIPTION
It could be possible that you have an action with different forms, data
or other stuff for different users, thats also accessible to
non-authenticated users. This makes the userIs method also easier to use
in this situation.